### PR TITLE
Fix reflected xss in laracom

### DIFF
--- a/project/resources/views/layouts/front/header-cart.blade.php
+++ b/project/resources/views/layouts/front/header-cart.blade.php
@@ -19,7 +19,7 @@
             <!-- search form -->
             <form action="{{route('search.product')}}" method="GET" class="form-inline" style="margin: 15px 0 0;">
                 <div class="input-group">
-                    <input type="text" name="q" class="form-control" placeholder="Search..." value="{!! request()->input('q') !!}">
+                    <input type="text" name="q" class="form-control" placeholder="Search..." value="{{ request()->input('q') }}">
                     <span class="input-group-btn">
                         <button type="submit" id="search-btn" class="btn btn-flat"><i class="fa fa-search"></i> Search</button>
                     </span>


### PR DESCRIPTION
### 📊 Metadata *
`laracom` is vulnerable for reflected `xss` or `cross-site-scripting`

#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-jsdecena%2Flaracom

### ⚙️ Description *

fix for xss in laracom

### 💻 Technical Description *


in line : https://github.com/jsdecena/laracom/blob/master/project/resources/views/layouts/front/header-cart.blade.php#L22

The expression `{ !! $data !!} Parses input without escape` , but instead using  `{{ $data }} escape html` and it can be used for prevent XSS

changed code : https://github.com/b1nslashsh/laracom/blob/master/project/resources/views/layouts/front/header-cart.blade.php#L22

### 🐛 Proof of Concept (PoC) *
![poc](https://user-images.githubusercontent.com/36979660/98770751-f4c7b880-2408-11eb-9bc4-fffacc92491f.png)

https://drive.google.com/drive/folders/1JG2RjM9NyW7xja5hLkQK8_JnH9Pdtqpq?usp=sharing

### 🔥 Proof of Fix (PoF) *
![poc1](https://user-images.githubusercontent.com/36979660/98685414-577b6e80-238d-11eb-823d-e78accaa57c4.png)
![poc2](https://user-images.githubusercontent.com/36979660/98685467-695d1180-238d-11eb-8ada-66d3965184db.png)


### 👍 User Acceptance Testing (UAT)
![poc3](https://user-images.githubusercontent.com/36979660/98685851-e5575980-238d-11eb-9fbf-c7315552a64b.png)
Searching products still working 👍 
